### PR TITLE
Handling game server list

### DIFF
--- a/server_list.go
+++ b/server_list.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+//ServerList is a struct that will contain an array of all available game servers and functions like get server name by id
+type ServerList struct {
+	packetID    string
+	servers     []Server
+	serverCount int
+}
+
+//Server is a struct that will be used to define a server in the list of game servers
+type Server struct {
+	serverID int
+}
+
+//NewServerList is a function that creates an array of servers from the AH packet
+func NewServerList(packet string) (serverList ServerList) {
+	if strings.HasPrefix(packet, "AH") {
+		serverList.packetID = "AH"
+		servers, err := getServersFromPacket(packet)
+		serverList.servers = servers
+		serverList.serverCount = len(servers)
+		if err != "" {
+			serverList.packetID = err
+			return serverList
+		}
+	} else {
+		serverList.packetID = "error"
+	}
+	return serverList
+}
+
+//getServersFromPacket is a function that creates an array of server ID from the AH packet
+func getServersFromPacket(packet string) (servers []Server, err string) {
+	if strings.Contains(packet, "|") && strings.Contains(packet, "AH") {
+		packetContent := strings.TrimPrefix(packet, "AH")   // removes the AH from the packet
+		fullServerData := strings.Split(packetContent, "|") // 601;1;110;0|605;1;110;0|609;1;110;0 -> {601;1;110;0, 605;1;110;0, 609;1;110;0}
+		for i := 0; i < len(fullServerData); i++ {
+			serversInfo := strings.Split(fullServerData[i], ";") // 601;1;110;0 -> {601, 1, 110, 0}
+			if len(serversInfo) == 4 {
+				serverID, err := strconv.Atoi(serversInfo[0]) // 601 ...
+				if err != nil {
+					return servers, "server ID Atoi Failed"
+				}
+				server := Server{serverID: serverID}
+				servers = append(servers, server)
+			} else { // invalid packet, serverInfo length != 4
+				return servers, "Invalid packet: serverInfo length = " + string(len(serversInfo)) + ", expected = 4"
+			}
+		}
+	}
+	return servers, ""
+}
+
+//GetServerNameByID is a function that returns a server name from its ID
+func GetServerNameByID(id int) (serverName string) {
+	switch id { // Source -> https://cadernis.fr/index.php?threads/aide-trouver-les-id-serveur-retro-dofus.2351/
+	case 601:
+		serverName = "Eratz"
+	case 602:
+		serverName = "Henual"
+	case 603:
+		serverName = "Nabur"
+	case 604:
+		serverName = "Arty"
+	case 605:
+		serverName = "Algathe"
+	case 606:
+		serverName = "Hogmeiser"
+	case 607:
+		serverName = "Droupik"
+	case 608:
+		serverName = "Ayuto"
+	case 609:
+		serverName = "Bilby"
+	case 610:
+		serverName = "Clustus"
+	case 611:
+		serverName = "Issering"
+	case 612:
+		serverName = "Boune"
+	default:
+		serverName = "Unknown"
+	}
+	return serverName
+}

--- a/server_list_test.go
+++ b/server_list_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetServersFromPacket(t *testing.T) {
+	var serverList ServerList
+	var err string
+	regularpacket := "AH601;1;110;0|605;1;110;0|609;1;110;0|604;1;110;0|608;1;110;0|603;1;110;0|607;1;110;0|611;1;110;0|602;1;110;0|606;1;110;0|610;1;110;0"
+
+	serverList.servers, err = getServersFromPacket(regularpacket) //expected = [{601} {605} {609} {604} {608} {603} {607} {611} {602} {606} {610}]
+	if len(serverList.servers) != 11 {
+		fmt.Println(err)
+		t.Error()
+	}
+
+	emptypacket := "AH"
+	serverList.servers, err = getServersFromPacket(emptypacket) //expected = []
+	if len(serverList.servers) != 0 {
+		fmt.Println(err)
+		t.Error()
+	}
+}


### PR DESCRIPTION
Ajout d'un fichier server_list.go accompagné de ses tests.

-> server_list.go

Permet de récupérer un array d'id de serveurs de jeu disponible ainsi que leur nom a partir d'un packet ayant pour ID "AH"